### PR TITLE
Add Subqueries to Delete

### DIFF
--- a/njord/src/lib.rs
+++ b/njord/src/lib.rs
@@ -30,6 +30,7 @@
 pub mod column;
 pub mod condition;
 pub mod keys;
+pub mod query;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 pub mod table;

--- a/njord/src/query.rs
+++ b/njord/src/query.rs
@@ -1,0 +1,26 @@
+/// The `QueryBuilder` trait.
+///
+/// Primarily used for subqueries within conditions.
+pub trait QueryBuilder<'a>: QueryBuilderClone<'a> {
+    fn to_sql(&self) -> String;
+}
+
+// A helper trait to enable cloning of `Box<dyn QueryBuilder>`
+pub trait QueryBuilderClone<'a> {
+    fn clone_box(&self) -> Box<dyn QueryBuilder<'a> + 'a>;
+}
+
+impl<'a, T> QueryBuilderClone<'a> for T
+where
+    T: 'a + QueryBuilder<'a> + Clone,
+{
+    fn clone_box(&self) -> Box<dyn QueryBuilder<'a> + 'a> {
+        Box::new(self.clone())
+    }
+}
+
+impl<'a> Clone for Box<dyn QueryBuilder<'a> + 'a> {
+    fn clone(&self) -> Box<dyn QueryBuilder<'a> + 'a> {
+        self.clone_box()
+    }
+}

--- a/njord/src/sqlite/update.rs
+++ b/njord/src/sqlite/update.rs
@@ -65,7 +65,7 @@ pub struct UpdateQueryBuilder<'a, T: Table + Default> {
     table: Option<T>,
     columns: Vec<String>,
     sub_queries: HashMap<String, SelectQueryBuilder<'a, T>>,
-    where_condition: Option<Condition>,
+    where_condition: Option<Condition<'a>>,
     order_by: Option<HashMap<Vec<String>, String>>,
     limit: Option<usize>,
     offset: Option<usize>,
@@ -116,7 +116,7 @@ impl<'a, T: Table + Default> UpdateQueryBuilder<'a, T> {
     /// # Arguments
     ///
     /// * `condition` - The condition to be applied in the WHERE clause.
-    pub fn where_clause(mut self, condition: Condition) -> Self {
+    pub fn where_clause(mut self, condition: Condition<'a>) -> Self {
         self.where_condition = Some(condition);
         self
     }

--- a/njord/src/sqlite/util.rs
+++ b/njord/src/sqlite/util.rs
@@ -173,14 +173,14 @@ pub fn remove_quotes_and_backslashes(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::condition::Condition;
+    use crate::condition::{Condition, Value};
 
     #[test]
     fn test_generate_where_condition_str() {
         // Test when condition is Some
-        let condition = Condition::Eq("age".to_string(), "30".to_string());
+        let condition = Condition::Eq("age".to_string(), Value::Literal("30".to_string()));
         let _result = generate_where_condition_str(Some(condition)); // TODO: need to fix this later
-                                                                    // assert_eq!(result, format!("WHERE {}", condition.build()));
+                                                                     // assert_eq!(result, format!("WHERE {}", condition.build()));
 
         // Test when condition is None
         let result = generate_where_condition_str(None);
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_generate_having_str() {
         // Test when group_by is true and having_condition is Some
-        let condition = Condition::Gt("COUNT(age)".to_string(), "5".to_string());
+        let condition = Condition::Gt("COUNT(age)".to_string(), Value::Literal("5".to_string()));
         let result = generate_having_str(true, Some(&condition));
         assert_eq!(result, format!("HAVING {}", condition.build()));
 

--- a/njord/src/util.rs
+++ b/njord/src/util.rs
@@ -41,14 +41,14 @@ pub enum JoinType {
 }
 
 #[derive(Clone)]
-pub struct Join {
+pub struct Join<'a> {
     pub join_type: JoinType,
     pub table: Arc<dyn Table>,
-    pub on_condition: Condition,
+    pub on_condition: Condition<'a>,
 }
 
-impl Join {
-    pub fn new(join_type: JoinType, table: Arc<dyn Table>, on_condition: Condition) -> Self {
+impl<'a> Join<'a> {
+    pub fn new(join_type: JoinType, table: Arc<dyn Table>, on_condition: Condition<'a>) -> Self {
         Join {
             join_type,
             table,

--- a/njord/tests/sqlite/delete_test.rs
+++ b/njord/tests/sqlite/delete_test.rs
@@ -1,6 +1,8 @@
 use super::User;
-use njord::condition::Condition;
+use njord::column::Column;
+use njord::condition::{Condition, Value};
 use njord::sqlite;
+use njord::sqlite::select::SelectQueryBuilder;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -10,19 +12,57 @@ fn delete() {
     let db_path = Path::new(&db_relative_path);
     let conn = sqlite::open(db_path);
 
-    let condition = Condition::Eq("address".to_string(), "Some Random Address 1".to_string());
+    let condition = Condition::Eq(
+        "address".to_string(),
+        Value::Literal("Some Random Address 1".to_string()),
+    );
 
     let mut order = HashMap::new();
     order.insert(vec!["id".to_string()], "DESC".to_string());
 
     match conn {
-        Ok(c) => {
+        Ok(ref c) => {
             let result = sqlite::delete(c)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order)
                 .limit(20)
                 .offset(0)
+                .build();
+            println!("{:?}", result);
+            assert!(result.is_ok());
+        }
+        Err(e) => {
+            panic!("Failed to DELETE: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn delete_with_subquery() {
+    let db_relative_path = "./db/insert.db";
+    let db_path = Path::new(&db_relative_path);
+    let conn = sqlite::open(db_path);
+
+    let mut order = HashMap::new();
+    order.insert(vec!["id".to_string()], "DESC".to_string());
+
+    match conn {
+        Ok(ref c) => {
+            let sub_query =
+                SelectQueryBuilder::new(c, vec![Column::<User>::Text("username".to_string())])
+                    .where_clause(Condition::Eq(
+                        "id".to_string(),
+                        Value::Literal(1.to_string()),
+                    ))
+                    .limit(1);
+
+            let condition =
+                Condition::Eq("address".to_string(), Value::Subquery(Box::new(sub_query)));
+
+            let result = sqlite::delete(c)
+                .from(User::default())
+                .where_clause(condition)
                 .build();
             println!("{:?}", result);
             assert!(result.is_ok());

--- a/njord/tests/sqlite/select_joins_test.rs
+++ b/njord/tests/sqlite/select_joins_test.rs
@@ -1,7 +1,7 @@
-use njord::column::Column;
 use njord::condition::Condition;
 use njord::sqlite;
 use njord::util::JoinType;
+use njord::{column::Column, condition::Value};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -21,10 +21,13 @@ fn select_inner_join() {
     ];
 
     // Assuming a hypothetical join condition: users.id = products.user_id
-    let join_condition = Condition::Eq("users.id".to_string(), "products.user_id".to_string());
+    let join_condition = Condition::Eq(
+        "users.id".to_string(),
+        Value::Literal("products.user_id".to_string()),
+    );
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(UsersWithJoin::default())
                 .join(
                     JoinType::Inner,
@@ -59,10 +62,13 @@ fn select_left_join() {
     ];
 
     // Assuming a hypothetical join condition: users.id = products.user_id
-    let join_condition = Condition::Eq("users.id".to_string(), "products.user_id".to_string());
+    let join_condition = Condition::Eq(
+        "users.id".to_string(),
+        Value::Literal("products.user_id".to_string()),
+    );
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(UsersWithJoin::default())
                 .join(JoinType::Left, Arc::new(Product::default()), join_condition)
                 .build();

--- a/njord/tests/sqlite/select_test.rs
+++ b/njord/tests/sqlite/select_test.rs
@@ -1,7 +1,7 @@
-use njord::column::Column;
 use njord::condition::Condition;
 use njord::keys::AutoIncrementPrimaryKey;
 use njord::sqlite;
+use njord::{column::Column, condition::Value};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -48,7 +48,10 @@ fn update() {
 
     let columns = vec!["username".to_string()];
 
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
 
     let table_row: User = User {
         id: AutoIncrementPrimaryKey::<usize>::new(Some(0)),
@@ -61,8 +64,8 @@ fn update() {
     order.insert(vec!["id".to_string()], "DESC".to_string());
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::update(&c, table_row)
+        Ok(ref c) => {
+            let result = sqlite::update(c, table_row)
                 .set(columns)
                 .where_clause(condition)
                 .order_by(order)
@@ -84,13 +87,16 @@ fn delete() {
     let db_path = Path::new(&db_relative_path);
     let conn = sqlite::open(db_path);
 
-    let condition = Condition::Eq("address".to_string(), "Some Random Address 1".to_string());
+    let condition = Condition::Eq(
+        "address".to_string(),
+        Value::Literal("Some Random Address 1".to_string()),
+    );
 
     let mut order = HashMap::new();
     order.insert(vec!["id".to_string()], "DESC".to_string());
 
     match conn {
-        Ok(c) => {
+        Ok(ref c) => {
             let result = sqlite::delete(c)
                 .from(User::default())
                 .where_clause(condition)
@@ -119,11 +125,14 @@ fn select() {
         Column::Text("email".to_string()),
         Column::Text("address".to_string()),
     ];
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .build();
@@ -149,11 +158,14 @@ fn select_distinct() {
         Column::Text("email".to_string()),
         Column::Text("address".to_string()),
     ];
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .distinct()
@@ -184,12 +196,15 @@ fn select_group_by() {
         Column::Text("email".to_string()),
         Column::Text("address".to_string()),
     ];
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
     let group_by = vec!["username".to_string(), "email".to_string()];
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .group_by(group_by)
@@ -216,15 +231,18 @@ fn select_order_by() {
         Column::Text("email".to_string()),
         Column::Text("address".to_string()),
     ];
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
     let group_by = vec!["username".to_string(), "email".to_string()];
 
     let mut order_by = HashMap::new();
     order_by.insert(vec!["email".to_string()], "ASC".to_string());
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order_by)
@@ -252,15 +270,18 @@ fn select_limit_offset() {
         Column::Text("email".to_string()),
         Column::Text("address".to_string()),
     ];
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
     let group_by = vec!["username".to_string(), "email".to_string()];
 
     let mut order_by = HashMap::new();
     order_by.insert(vec!["id".to_string()], "DESC".to_string());
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order_by)
@@ -290,17 +311,20 @@ fn select_having() {
         Column::Text("email".to_string()),
         Column::Text("address".to_string()),
     ];
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
     let group_by = vec!["username".to_string(), "email".to_string()];
 
     let mut order_by = HashMap::new();
     order_by.insert(vec!["email".to_string()], "DESC".to_string());
 
-    let having_condition = Condition::Gt("id".to_string(), "1".to_string());
+    let having_condition = Condition::Gt("id".to_string(), Value::Literal("1".to_string()));
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order_by)
@@ -330,22 +354,31 @@ fn select_except() {
         Column::Text("address".to_string()),
     ];
 
-    let condition1 = Condition::Eq("username".to_string(), "mjovanc".to_string());
-    let condition2 = Condition::Eq("username".to_string(), "otheruser".to_string());
-    let condition3 = Condition::Eq("username".to_string(), "anotheruser".to_string());
+    let condition1 = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
+    let condition2 = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("otheruser".to_string()),
+    );
+    let condition3 = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("anotheruser".to_string()),
+    );
 
     match conn {
-        Ok(c) => {
+        Ok(ref c) => {
             // Create a new connection for each query builder
-            let query1 = sqlite::select(&c, columns.clone())
+            let query1 = sqlite::select(c, columns.clone())
                 .from(User::default())
                 .where_clause(condition1);
 
-            let query2 = sqlite::select(&c, columns.clone())
+            let query2 = sqlite::select(c, columns.clone())
                 .from(User::default())
                 .where_clause(condition2);
 
-            let query3 = sqlite::select(&c, columns.clone())
+            let query3 = sqlite::select(c, columns.clone())
                 .from(User::default())
                 .where_clause(condition3);
 
@@ -376,17 +409,17 @@ fn select_union() {
         Column::Text("address".to_string()),
     ];
 
-    let condition1 = Condition::Eq("id".to_string(), 42.to_string());
-    let condition2 = Condition::Eq("id".to_string(), 43.to_string());
+    let condition1 = Condition::Eq("id".to_string(), Value::Literal(42.to_string()));
+    let condition2 = Condition::Eq("id".to_string(), Value::Literal(43.to_string()));
 
     match conn {
-        Ok(c) => {
+        Ok(ref c) => {
             // Create a new connection for each query builder
-            let query1 = sqlite::select(&c, columns.clone())
+            let query1 = sqlite::select(c, columns.clone())
                 .from(User::default())
                 .where_clause(condition1);
 
-            let query2 = sqlite::select(&c, columns.clone())
+            let query2 = sqlite::select(c, columns.clone())
                 .from(User::default())
                 .where_clause(condition2);
 
@@ -466,17 +499,20 @@ fn select_in() {
     let condition = Condition::And(
         Box::new(Condition::In(
             "username".to_string(),
-            vec!["mjovanc".to_string(), "otheruser".to_string()],
+            vec![
+                Value::Literal("mjovanc".to_string()),
+                Value::Literal("otheruser".to_string()),
+            ],
         )),
         Box::new(Condition::NotIn(
             "username".to_string(),
-            vec!["chasewillden".to_string()],
+            vec![Value::Literal("chasewillden".to_string())],
         )),
     );
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::select(&c, columns)
+        Ok(ref c) => {
+            let result = sqlite::select(c, columns)
                 .from(User::default())
                 .where_clause(condition)
                 .build();

--- a/njord/tests/sqlite/update_test.rs
+++ b/njord/tests/sqlite/update_test.rs
@@ -1,6 +1,6 @@
 use super::User;
 use njord::column::Column;
-use njord::condition::Condition;
+use njord::condition::{Condition, Value};
 use njord::keys::AutoIncrementPrimaryKey;
 use njord::sqlite::select::SelectQueryBuilder;
 use njord::sqlite::{self};
@@ -15,7 +15,10 @@ fn update() {
 
     let columns = vec!["username".to_string()];
 
-    let condition = Condition::Eq("username".to_string(), "mjovanc".to_string());
+    let condition = Condition::Eq(
+        "username".to_string(),
+        Value::Literal("mjovanc".to_string()),
+    );
 
     let table_row: User = User {
         id: AutoIncrementPrimaryKey::<usize>::new(Some(0)),
@@ -28,8 +31,8 @@ fn update() {
     order.insert(vec!["id".to_string()], "DESC".to_string());
 
     match conn {
-        Ok(c) => {
-            let result = sqlite::update(&c, table_row)
+        Ok(ref c) => {
+            let result = sqlite::update(c, table_row)
                 .set(columns)
                 .where_clause(condition)
                 .order_by(order)
@@ -66,7 +69,7 @@ fn update_with_sub_queries() {
                 .from(User::default())
                 .where_clause(Condition::Eq(
                     "email".to_string(),
-                    "mjovanc@icloud.com".to_string(),
+                    Value::Literal("mjovanc@icloud.com".to_string()),
                 ))
                 .limit(1);
 
@@ -75,7 +78,10 @@ fn update_with_sub_queries() {
             let result = sqlite::update(&c, table_row)
                 .set(columns)
                 .set_subqueries(set_subqueries)
-                .where_clause(Condition::Eq("username".to_owned(), "otheruser".to_owned()))
+                .where_clause(Condition::Eq(
+                    "username".to_owned(),
+                    Value::Literal("mjovanc".to_owned()),
+                ))
                 .build();
 
             println!("{:?}", result);


### PR DESCRIPTION
This does add a little complexity. I'm not sure the other way to implement this gracefully though.

Delete without a subquery, using just the literals:

```rust
match conn {
    Ok(ref c) => {
        let condition = Condition::Eq(
            "address".to_string(),
            Value::Literal("Some Random Address 1".to_string()),
        );

        let result = sqlite::delete(c)
            .from(User::default())
            .where_clause(condition)
            .order_by(order)
            .limit(20)
            .offset(0)
            .build();
        println!("{:?}", result);
        assert!(result.is_ok());
    }
    Err(e) => {
        panic!("Failed to DELETE: {:?}", e);
    }
}
```

Delete with subquery:

```rust
match conn {
    Ok(ref c) => {
        let sub_query =
            SelectQueryBuilder::new(c, vec![Column::<User>::Text("username".to_string())])
                .where_clause(Condition::Eq(
                    "id".to_string(),
                    Value::Literal(1.to_string()),
                ))
                .limit(1);

        let condition =
            Condition::Eq("address".to_string(), Value::Subquery(Box::new(sub_query)));

        let result = sqlite::delete(c)
            .from(User::default())
            .where_clause(condition)
            .build();
        println!("{:?}", result);
        assert!(result.is_ok());
    }
    Err(e) => {
        panic!("Failed to DELETE: {:?}", e);
    }
}
```