### PR TITLE
Remove all connections from structs to prevent borrowing issues

### DIFF
--- a/njord/src/mysql/delete.rs
+++ b/njord/src/mysql/delete.rs
@@ -46,20 +46,15 @@ use crate::table::Table;
 
 /// Constructs a new DELETE query builder.
 ///
-/// # Arguments
-///
-/// * `conn` - A `PooledConn` to the MySql database.
-///
 /// # Returns
 ///
 /// A `DeleteQueryBuilder` instance.
-pub fn delete<T: Table + Default>(conn: &mut PooledConn) -> DeleteQueryBuilder<T> {
-    DeleteQueryBuilder::new(conn)
+pub fn delete<T: Table + Default>() -> DeleteQueryBuilder<'static, T> {
+    DeleteQueryBuilder::new()
 }
 
 /// A builder for constructing DELETE queries.
 pub struct DeleteQueryBuilder<'a, T: Table + Default> {
-    conn: &'a mut PooledConn,
     table: Option<T>,
     where_condition: Option<Condition<'a>>,
     order_by: Option<HashMap<Vec<String>, String>>,
@@ -69,13 +64,8 @@ pub struct DeleteQueryBuilder<'a, T: Table + Default> {
 
 impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
     /// Creates a new `DeleteQueryBuilder` instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `conn` - A `PooledConn` to the MySql database.
-    pub fn new(conn: &'a mut PooledConn) -> Self {
+    pub fn new() -> Self {
         DeleteQueryBuilder {
-            conn,
             table: None,
             where_condition: None,
             order_by: None,
@@ -136,10 +126,14 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
 
     /// Builds and executes the DELETE query.
     ///
+    /// # Arguments
+    ///
+    /// * `conn` - A `PooledConn` to the MySql database.
+    /// 
     /// # Returns
     ///
     /// A `Result` indicating success or failure of the deletion operation.
-    pub fn build(self) -> Result<(), String> {
+    pub fn build(self, conn: &mut PooledConn) -> Result<(), String> {
         let table_name = self
             .table
             .as_ref()
@@ -165,7 +159,7 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
         info!("{}", query);
 
         // Execute SQL
-        let _ = self.conn.query_drop(&query.to_string());
+        let _ = conn.query_drop(&query.to_string());
 
         Ok(())
     }

--- a/njord/src/mysql/select.rs
+++ b/njord/src/mysql/select.rs
@@ -51,7 +51,6 @@ use crate::util::{Join, JoinType};
 ///
 /// # Arguments
 ///
-/// * `conn` - A `PooledConn` to the MySql database.
 /// * `columns` - A vector of strings representing the columns to be selected.
 ///
 /// # Returns
@@ -83,7 +82,6 @@ impl<'a, T: Table + Default> SelectQueryBuilder<'a, T> {
     ///
     /// # Arguments
     ///
-    /// * `conn` - A `PooledConn` to the MySql database.
     /// * `columns` - A vector of strings representing the columns to be selected.
     pub fn new(columns: Vec<Column<'a>>) -> Self {
         SelectQueryBuilder {
@@ -350,6 +348,10 @@ impl<'a, T: Table + Default> SelectQueryBuilder<'a, T> {
     }
 
     /// Builds and executes the SELECT query.
+    /// 
+    /// # Arguments
+    ///
+    /// * `conn` - A mutable reference to the database connection.
     ///
     /// # Returns
     ///

--- a/njord/src/mysql/update.rs
+++ b/njord/src/mysql/update.rs
@@ -50,19 +50,17 @@ use super::select::SelectQueryBuilder;
 ///
 /// # Arguments
 ///
-/// * `conn` - A `PooledConn` to the MySql database.
 /// * `table` - An instance of the table to be updated.
 ///
 /// # Returns
 ///
 /// An `UpdateQueryBuilder` instance.
-pub fn update<T: Table + Default>(conn: &mut PooledConn, table: T) -> UpdateQueryBuilder<T> {
-    UpdateQueryBuilder::new(conn, table)
+pub fn update<T: Table + Default>(table: T) -> UpdateQueryBuilder<'static, T> {
+    UpdateQueryBuilder::new(table)
 }
 
 /// A builder for constructing UPDATE queries.
 pub struct UpdateQueryBuilder<'a, T: Table + Default> {
-    conn: &'a mut PooledConn,
     table: Option<T>,
     columns: Vec<String>,
     sub_queries: HashMap<String, SelectQueryBuilder<'a, T>>,
@@ -77,11 +75,9 @@ impl<'a, T: Table + Default> UpdateQueryBuilder<'a, T> {
     ///
     /// # Arguments
     ///
-    /// * `conn` - A `PooledConn` to the MySql database.
     /// * `table` - An instance of the table to be updated.
-    pub fn new(conn: &'a mut PooledConn, table: T) -> Self {
+    pub fn new(table: T) -> Self {
         UpdateQueryBuilder {
-            conn,
             table: Some(table),
             columns: Vec::new(),
             sub_queries: HashMap::new(),
@@ -154,10 +150,14 @@ impl<'a, T: Table + Default> UpdateQueryBuilder<'a, T> {
 
     /// Builds and executes the UPDATE query.
     ///
+    /// # Arguments
+    ///
+    /// * `conn` - A mutable reference to the MySQL connection.
+    /// 
     /// # Returns
     ///
     /// A `Result` indicating success or failure of the update operation.
-    pub fn build(self) -> Result<(), String> {
+    pub fn build(self, conn: &mut PooledConn) -> Result<(), String> {
         let table_name = self
             .table
             .as_ref()
@@ -220,7 +220,7 @@ impl<'a, T: Table + Default> UpdateQueryBuilder<'a, T> {
         info!("{}", query);
 
         // Prepare SQL statement
-        let _ = self.conn.query_drop(query.as_str());
+        let _ = conn.query_drop(query.as_str());
 
         Ok(())
     }

--- a/njord/src/oracle/delete.rs
+++ b/njord/src/oracle/delete.rs
@@ -46,20 +46,15 @@ use crate::table::Table;
 
 /// Constructs a new DELETE query builder.
 ///
-/// # Arguments
-///
-/// * `conn` - A `Connection` to the Oracle database.
-///
 /// # Returns
 ///
 /// A `DeleteQueryBuilder` instance.
-pub fn delete<T: Table + Default>(conn: &mut Connection) -> DeleteQueryBuilder<T> {
-    DeleteQueryBuilder::new(conn)
+pub fn delete<T: Table + Default>() -> DeleteQueryBuilder<'static, T> {
+    DeleteQueryBuilder::new()
 }
 
 /// A builder for constructing DELETE queries.
 pub struct DeleteQueryBuilder<'a, T: Table + Default> {
-    conn: &'a mut Connection,
     table: Option<T>,
     where_condition: Option<Condition<'a>>,
     order_by: Option<HashMap<Vec<String>, String>>,
@@ -69,13 +64,8 @@ pub struct DeleteQueryBuilder<'a, T: Table + Default> {
 
 impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
     /// Creates a new `DeleteQueryBuilder` instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `conn` - A `Connection` to the Oracle database.
-    pub fn new(conn: &'a mut Connection) -> Self {
+    pub fn new() -> Self {
         DeleteQueryBuilder {
-            conn,
             table: None,
             where_condition: None,
             order_by: None,
@@ -135,11 +125,15 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
     }
 
     /// Builds and executes the DELETE query.
+    /// 
+    /// # Arguments
+    ///
+    /// * `conn` - A mutable reference to the Oracle connection.
     ///
     /// # Returns
     ///
     /// A `Result` indicating success or failure of the deletion operation.
-    pub fn build(self) -> Result<(), String> {
+    pub fn build(self, conn: &mut Connection) -> Result<(), String> {
         let table_name = self
             .table
             .as_ref()
@@ -165,7 +159,7 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
         info!("{}", query);
 
         // Execute SQL
-        let _ = self.conn.execute(&query, &[]);
+        let _ = conn.execute(&query, &[]);
 
         Ok(())
     }

--- a/njord/src/oracle/select.rs
+++ b/njord/src/oracle/select.rs
@@ -50,7 +50,6 @@ use crate::util::{Join, JoinType};
 ///
 /// # Arguments
 ///
-/// * `conn` - A `Connection` to the Oracle database.
 /// * `columns` - A vector of strings representing the columns to be selected.
 ///
 /// # Returns
@@ -80,7 +79,6 @@ impl<'a, T: Table + Default> SelectQueryBuilder<'a, T> {
     ///
     /// # Arguments
     ///
-    /// * `conn` - A `Connection` to the Oracle database.
     /// * `columns` - A vector of strings representing the columns to be selected.
     pub fn new(columns: Vec<Column<'a>>) -> Self {
         SelectQueryBuilder {
@@ -322,6 +320,10 @@ impl<'a, T: Table + Default> SelectQueryBuilder<'a, T> {
     }
 
     /// Builds and executes the SELECT query.
+    /// 
+    /// # Arguments
+    ///
+    /// * `conn` - A mutable reference to the database connection.
     ///
     /// # Returns
     ///

--- a/njord/src/sqlite/delete.rs
+++ b/njord/src/sqlite/delete.rs
@@ -45,20 +45,15 @@ use crate::table::Table;
 
 /// Constructs a new DELETE query builder.
 ///
-/// # Arguments
-///
-/// * `conn` - A `rusqlite::Connection` to the SQLite database.
-///
 /// # Returns
 ///
 /// A `DeleteQueryBuilder` instance.
-pub fn delete<T: Table + Default>(conn: &Connection) -> DeleteQueryBuilder<T> {
-    DeleteQueryBuilder::new(conn)
+pub fn delete<T: Table + Default>() -> DeleteQueryBuilder<'static, T> {
+    DeleteQueryBuilder::new()
 }
 
 /// A builder for constructing DELETE queries.
 pub struct DeleteQueryBuilder<'a, T: Table + Default> {
-    conn: &'a Connection,
     table: Option<T>,
     where_condition: Option<Condition<'a>>,
     order_by: Option<HashMap<Vec<String>, String>>,
@@ -72,9 +67,8 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
     /// # Arguments
     ///
     /// * `conn` - A `rusqlite::Connection` to the SQLite database.
-    pub fn new(conn: &'a Connection) -> Self {
+    pub fn new() -> Self {
         DeleteQueryBuilder {
-            conn,
             table: None,
             where_condition: None,
             order_by: None,
@@ -134,11 +128,15 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
     }
 
     /// Builds and executes the DELETE query.
-    ///
+    /// 
+    /// # Arguments
+    /// 
+    /// * `conn` - A reference to the database connection.
+    /// 
     /// # Returns
     ///
     /// A `Result` indicating success or failure of the deletion operation.
-    pub fn build(self) -> Result<(), String> {
+    pub fn build(self, conn: &Connection) -> Result<(), String> {
         let table_name = self
             .table
             .as_ref()
@@ -164,7 +162,7 @@ impl<'a, T: Table + Default> DeleteQueryBuilder<'a, T> {
         info!("{}", query);
 
         // Execute SQL
-        let _ = self.conn.execute(&query.to_string(), []);
+        let _ = conn.execute(&query.to_string(), []);
 
         Ok(())
     }

--- a/njord/tests/mssql/delete_test.rs
+++ b/njord/tests/mssql/delete_test.rs
@@ -14,13 +14,13 @@ async fn delete_row() {
 
     match conn {
         Ok(ref mut c) => {
-            let result = mssql::delete(c)
+            let result = mssql::delete()
                 .from(User::default())
                 .where_clause(Condition::Eq(
                     "username".to_string(),
                     Value::Literal("chasewillden2".to_string()),
                 ))
-                .build()
+                .build(c)
                 .await;
             assert!(result.is_ok());
         }

--- a/njord/tests/mysql/select_joins_test.rs
+++ b/njord/tests/mysql/select_joins_test.rs
@@ -35,10 +35,10 @@ fn delete_mock_data<T: Table + Clone + Default>(names: Vec<String>, column: Stri
                 .map(Value::Literal) // Wrap each username as a Value::Literal
                 .collect();
 
-            let result = mysql::delete(c)
+            let result = mysql::delete()
                 .from(T::default())
                 .where_clause(Condition::In(column, value_list))
-                .build();
+                .build(c);
             assert!(result.is_ok());
         }
         Err(e) => {

--- a/njord/tests/mysql/update_test.rs
+++ b/njord/tests/mysql/update_test.rs
@@ -19,12 +19,12 @@ fn delete_row() {
 
     match conn {
         Ok(ref mut c) => {
-            let result = mysql::update(c, User::default())
+            let result = mysql::update(User::default())
                 .set(columns)
                 .where_clause(condition)
                 .limit(4)
                 .offset(0)
-                .build();
+                .build(c);
             assert!(result.is_ok());
         }
         Err(e) => {

--- a/njord/tests/oracle/delete_test.rs
+++ b/njord/tests/oracle/delete_test.rs
@@ -13,13 +13,13 @@ fn delete_row() {
 
     match conn {
         Ok(ref mut c) => {
-            let result = oracle::delete(c)
+            let result = oracle::delete()
                 .from(User::default())
                 .where_clause(Condition::Eq(
                     "username".to_string(),
                     Value::Literal("chasewillden2".to_string()),
                 ))
-                .build();
+                .build(c);
             assert!(result.is_ok());
         }
         Err(e) => {

--- a/njord/tests/oracle/update_test.rs
+++ b/njord/tests/oracle/update_test.rs
@@ -19,12 +19,12 @@ fn update_row() {
 
     match conn {
         Ok(ref mut c) => {
-            let result = oracle::update(c, User::default())
+            let result = oracle::update(User::default())
                 .set(columns)
                 .where_clause(condition)
                 .limit(4)
                 .offset(0)
-                .build();
+                .build(c);
             assert!(result.is_ok());
         }
         Err(e) => {

--- a/njord/tests/sqlite/delete_test.rs
+++ b/njord/tests/sqlite/delete_test.rs
@@ -22,13 +22,13 @@ fn delete() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::delete(c)
+            let result = sqlite::delete()
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order)
                 .limit(20)
                 .offset(0)
-                .build();
+                .build(c);
             println!("{:?}", result);
             assert!(result.is_ok());
         }
@@ -50,7 +50,7 @@ fn delete_with_subquery() {
     match conn {
         Ok(ref c) => {
             let sub_query =
-                SelectQueryBuilder::<User>::new(c, vec![Column::Text("username".to_string())])
+                SelectQueryBuilder::<User>::new(vec![Column::Text("username".to_string())])
                     .where_clause(Condition::Eq(
                         "id".to_string(),
                         Value::Literal(1.to_string()),
@@ -60,10 +60,10 @@ fn delete_with_subquery() {
             let condition =
                 Condition::Eq("address".to_string(), Value::Subquery(Box::new(sub_query)));
 
-            let result = sqlite::delete(c)
+            let result = sqlite::delete()
                 .from(User::default())
                 .where_clause(condition)
-                .build();
+                .build(c);
             println!("{:?}", result);
             assert!(result.is_ok());
         }

--- a/njord/tests/sqlite/insert_test.rs
+++ b/njord/tests/sqlite/insert_test.rs
@@ -39,7 +39,6 @@ fn insert_with_sub_query() {
     match conn {
         Ok(ref mut c) => {
             let subquery = sqlite::select(
-                c,
                 vec![
                     Column::Text("username".to_string()),
                     Column::Text("email".to_string()),

--- a/njord/tests/sqlite/select_joins_test.rs
+++ b/njord/tests/sqlite/select_joins_test.rs
@@ -27,14 +27,14 @@ fn select_inner_join() {
     );
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(UsersWithJoin::default())
                 .join(
                     JoinType::Inner,
                     Arc::new(Product::default()),
                     join_condition,
                 )
-                .build();
+                .build(c);
             match result {
                 Ok(r) => {
                     // Check the number of results and assert against expected values
@@ -68,10 +68,10 @@ fn select_left_join() {
     );
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(UsersWithJoin::default())
                 .join(JoinType::Left, Arc::new(Product::default()), join_condition)
-                .build();
+                .build(c);
             match result {
                 Ok(r) => {
                     // Check the number of results and assert against expected values

--- a/njord/tests/sqlite/select_test.rs
+++ b/njord/tests/sqlite/select_test.rs
@@ -65,13 +65,13 @@ fn update() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::update(c, table_row)
+            let result = sqlite::update(table_row)
                 .set(columns)
                 .where_clause(condition)
                 .order_by(order)
                 .limit(4)
                 .offset(0)
-                .build();
+                .build(c);
             println!("{:?}", result);
             assert!(result.is_ok());
         }
@@ -97,13 +97,13 @@ fn delete() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::delete(c)
+            let result = sqlite::delete()
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order)
                 .limit(20)
                 .offset(0)
-                .build();
+                .build(c);
             println!("{:?}", result);
             assert!(result.is_ok());
         }
@@ -132,10 +132,10 @@ fn select() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => assert_eq!(r.len(), 2),
@@ -165,11 +165,11 @@ fn select_distinct() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
                 .distinct()
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => {
@@ -204,11 +204,11 @@ fn select_group_by() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
                 .group_by(group_by)
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => assert_eq!(r.len(), 1),
@@ -242,12 +242,12 @@ fn select_order_by() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order_by)
                 .group_by(group_by)
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => assert_eq!(r.len(), 1),
@@ -281,14 +281,14 @@ fn select_limit_offset() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order_by)
                 .group_by(group_by)
                 .limit(1)
                 .offset(0)
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => assert_eq!(r.len(), 1),
@@ -324,13 +324,13 @@ fn select_having() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
                 .order_by(order_by)
                 .group_by(group_by)
                 .having(having_condition)
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => assert_eq!(r.len(), 1),
@@ -370,20 +370,20 @@ fn select_except() {
     match conn {
         Ok(ref c) => {
             // Create a new connection for each query builder
-            let query1 = sqlite::select(c, columns.clone())
+            let query1 = sqlite::select(columns.clone())
                 .from(User::default())
                 .where_clause(condition1);
 
-            let query2 = sqlite::select(c, columns.clone())
+            let query2 = sqlite::select(columns.clone())
                 .from(User::default())
                 .where_clause(condition2);
 
-            let query3 = sqlite::select(c, columns.clone())
+            let query3 = sqlite::select(columns.clone())
                 .from(User::default())
                 .where_clause(condition3);
 
             // Test a chain of EXCEPT queries (query1 EXCEPT query2 EXCEPT query3)
-            let result = query1.except(query2).except(query3).build();
+            let result = query1.except(query2).except(query3).build(c);
 
             match result {
                 Ok(r) => {
@@ -415,16 +415,16 @@ fn select_union() {
     match conn {
         Ok(ref c) => {
             // Create a new connection for each query builder
-            let query1 = sqlite::select(c, columns.clone())
+            let query1 = sqlite::select(columns.clone())
                 .from(User::default())
                 .where_clause(condition1);
 
-            let query2 = sqlite::select(c, columns.clone())
+            let query2 = sqlite::select(columns.clone())
                 .from(User::default())
                 .where_clause(condition2);
 
             // Test a chain of UNION queries (query1 UNION query2)
-            let result = query1.union(query2).build();
+            let result = query1.union(query2).build(c);
 
             match result {
                 Ok(r) => {
@@ -456,7 +456,7 @@ fn select_sub_queries() {
 
     match conn {
         Ok(c) => {
-            let sub_query = sqlite::select(&c, vec![Column::Text("username".to_string())])
+            let sub_query = sqlite::select(vec![Column::Text("username".to_string())])
                 .from(UserWithSubQuery::default());
 
             let columns = vec![
@@ -467,9 +467,9 @@ fn select_sub_queries() {
                 Column::SubQuery(Box::new(sub_query), "additional_address".to_string()),
             ];
 
-            let result = sqlite::select(&c, columns)
+            let result = sqlite::select(columns)
                 .from(UserWithSubQuery::default())
-                .build();
+                .build(&c);
 
             match result {
                 Ok(r) => {
@@ -512,10 +512,10 @@ fn select_in() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::select(c, columns)
+            let result = sqlite::select(columns)
                 .from(User::default())
                 .where_clause(condition)
-                .build();
+                .build(c);
 
             match result {
                 Ok(r) => assert_eq!(r.len(), 2),

--- a/njord/tests/sqlite/update_test.rs
+++ b/njord/tests/sqlite/update_test.rs
@@ -32,13 +32,13 @@ fn update() {
 
     match conn {
         Ok(ref c) => {
-            let result = sqlite::update(c, table_row)
+            let result = sqlite::update(table_row)
                 .set(columns)
                 .where_clause(condition)
                 .order_by(order)
                 .limit(4)
                 .offset(0)
-                .build();
+                .build(c);
             println!("{:?}", result);
             assert!(result.is_ok());
         }
@@ -65,7 +65,7 @@ fn update_with_sub_queries() {
 
     match conn {
         Ok(c) => {
-            let sub_query = SelectQueryBuilder::new(&c, vec![Column::Text("email".to_string())])
+            let sub_query = SelectQueryBuilder::new(vec![Column::Text("email".to_string())])
                 .from(User::default())
                 .where_clause(Condition::Eq(
                     "email".to_string(),
@@ -75,14 +75,14 @@ fn update_with_sub_queries() {
 
             let set_subqueries = HashMap::from([("email".to_string(), sub_query)]);
 
-            let result = sqlite::update(&c, table_row)
+            let result = sqlite::update(table_row)
                 .set(columns)
                 .set_subqueries(set_subqueries)
                 .where_clause(Condition::Eq(
                     "username".to_owned(),
                     Value::Literal("mjovanc".to_owned()),
                 ))
-                .build();
+                .build(&c);
 
             println!("{:?}", result);
             assert!(result.is_ok());


### PR DESCRIPTION
I am sorry for the larger PR, I'll trim these down in the future!

The main purpose of this PR is to prevent the issue of who owns the connection instances. Removing it from each of the structs allows the user of the structs to own the connection object. This will prevent borrowing errors.

Remove conn from structs:
 - [x] MySQL
 - [x] SQLite
 - [x] Oracle
 - [x] MSSQL 

Additionally, many of the tests would fail because of too many connections, this also will help prevent that error since you can reuse connections easier.