### PR TITLE
add raw_execute to oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ A highly versatile and feature-rich ORM library for Rust, designed to simplify d
 | ---------------- | ---- | ------ | ------ | ------ | ------ | ------- | ------------- | ---------------------------------- |
 | SQLite           | ✅   | ✅     | ✅     | ✅     | ✅     | ✅      | ✅            | Fully supported.                  |
 | PostgreSQL       | 🏗️   | 🏗️     | 🏗️     | 🏗️     | 🏗️     | 🏗️      | 🏗️            | In development.                   |
-| MySQL            | ✅   | ✅     | ✅     | ✅     | ✅     | ✅      | ✅            | Fully supported.                  |
+| MySQL            | ✅   | ✅     | ✅     | ✅     | ✅     | 🏗️      | ✅            | Fully supported.                  |
 | MariaDB          | 🏗️   | 🏗️     | 🏗️     | 🏗️     | 🏗️     | 🏗️      | 🏗️            | In development.                   |
 | Oracle           | ✅   | ✅     | ✅     | ✅     | ✅     | ✅      | ✅            | Fully supported.                  |
-| MSSQL            | ✅   | ✅     | ✅     | ✅     | ✅     | ✅      | ✅            | Fully supported.                  |
+| MSSQL            | ✅   | ✅     | ✅     | ✅     | ✅     | 🏗️      | ✅            | Fully supported.                  |
 | IBM Db2          | ❌   | ❌     | ❌     | ❌     | ❌     | ❌      | ❌            | Not supported, help us implement! |
 | LDAP             | ❌   | ❌     | ❌     | ❌     | ❌     | ❌      | ❌            | Not supported, help us implement! |
 | Sybase           | ❌   | ❌     | ❌     | ❌     | ❌     | ❌      | ❌            | Not supported, help us implement! |

--- a/njord/tests/oracle/select_test.rs
+++ b/njord/tests/oracle/select_test.rs
@@ -3,6 +3,7 @@ use njord::condition::Condition;
 use njord::keys::AutoIncrementPrimaryKey;
 use njord::oracle::{self};
 use njord::{column::Column, condition::Value};
+use njord_derive::sql;
 use std::collections::HashMap;
 
 use crate::{User, UserWithSubQuery};
@@ -741,6 +742,28 @@ fn select_in() {
                     "select_in_test3".to_string(),
                 ],
             );
+        }
+        Err(e) => panic!("Failed to SELECT: {:?}", e),
+    };
+}
+
+#[test]
+fn raw_execute() {
+    let connection_string = "//localhost:1521/FREEPDB1";
+    let mut conn = oracle::open("njord_user", "njord_password", connection_string);
+
+    let username = "mjovanc";
+
+    let query = sql! {
+        SELECT *
+        FROM users
+        WHERE username = {username}
+    };
+
+    match conn {
+        Ok(ref mut c) => {
+            let result = oracle::select::raw_execute::<User>(&query, c);
+            assert!(result.is_ok());
         }
         Err(e) => panic!("Failed to SELECT: {:?}", e),
     };


### PR DESCRIPTION
Add ability to execute a raw sql select statement to oracle. 

Implementing this, I realized that there needs to be a separation of select raw sql and everything else because select raw sql will need to to map it to an actual object, where the others won't