### PR TITLE
Add raw_execute outside of select

### DIFF
--- a/njord/src/mssql/mod.rs
+++ b/njord/src/mssql/mod.rs
@@ -78,3 +78,21 @@ pub async fn open(connection_string: &str) -> Result<Connection, Error> {
     };
     return Ok(Connection { client });
 }
+
+/// Executes a raw SQL query and returns a vector of table rows.
+///
+/// # Arguments
+///
+/// * `sql` - The SQL query to execute.
+/// * `conn` - A reference to the database connection.
+///
+/// # Returns
+///
+/// A `Result` containing a vector of table rows if successful,
+/// or a `rusqlite::Error` if an error occurs during the execution.
+pub async fn raw_execute(conn: &mut Connection, sql: &str) -> Result<(), MSSQLError> {
+    match conn.client.execute(sql, &[]).await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/njord/src/mysql/mod.rs
+++ b/njord/src/mysql/mod.rs
@@ -29,7 +29,7 @@
 //! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 //! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use mysql::{Error, Pool, PooledConn};
+use mysql::{prelude::Queryable, Error, Pool, PooledConn};
 
 pub mod delete;
 pub mod error;
@@ -61,4 +61,22 @@ pub fn open(url: &str) -> Result<PooledConn, Error> {
     let conn = pool.get_conn()?;
 
     Ok(conn)
+}
+
+/// Executes a raw SQL query and returns a vector of table rows.
+///
+/// # Arguments
+///
+/// * `sql` - The SQL query to execute.
+/// * `conn` - A reference to the database connection.
+///
+/// # Returns
+///
+/// A `Result` containing a vector of table rows if successful,
+/// or a `rusqlite::Error` if an error occurs during the execution.
+pub fn raw_execute(conn: &mut PooledConn, sql: &str) -> Result<(), MySqlError> {
+    match conn.query_drop(sql) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
 }

--- a/njord/src/oracle/mod.rs
+++ b/njord/src/oracle/mod.rs
@@ -73,3 +73,21 @@ pub fn open(username: &str, password: &str, connect_string: &str) -> Result<Conn
         }
     }
 }
+
+/// Executes a raw SQL query and returns a vector of table rows.
+///
+/// # Arguments
+///
+/// * `sql` - The SQL query to execute.
+/// * `conn` - A reference to the database connection.
+///
+/// # Returns
+///
+/// A `Result` containing a vector of table rows if successful,
+/// or a `rusqlite::Error` if an error occurs during the execution.
+pub fn raw_execute(conn: &Connection, sql: &str) -> Result<(), OracleError> {
+    match conn.execute(sql, &[]) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/njord/src/sqlite/mod.rs
+++ b/njord/src/sqlite/mod.rs
@@ -87,3 +87,21 @@ pub fn open_in_memory() -> Result<Connection, Error> {
 
     Ok(conn)
 }
+
+/// Executes a raw SQL query and returns a vector of table rows.
+///
+/// # Arguments
+///
+/// * `sql` - The SQL query to execute.
+/// * `conn` - A reference to the database connection.
+///
+/// # Returns
+///
+/// A `Result` containing a vector of table rows if successful,
+/// or a `rusqlite::Error` if an error occurs during the execution.
+pub fn raw_execute(conn: &Connection, sql: &str) -> Result<(), SqliteError> {
+    match conn.execute_batch(sql) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/njord/tests/sqlite/mod.rs
+++ b/njord/tests/sqlite/mod.rs
@@ -1,6 +1,7 @@
 mod delete_test;
 mod insert_test;
 mod open_test;
+mod raw_test;
 mod select_joins_test;
 mod select_test;
 mod update_test;

--- a/njord/tests/sqlite/raw_test.rs
+++ b/njord/tests/sqlite/raw_test.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+use njord::sqlite;
+use njord_derive::sql;
+
+#[test]
+fn execute_raw_sql() {
+    let db_relative_path = "./db/insert.db";
+    let db_path = Path::new(&db_relative_path);
+    let conn = sqlite::open(db_path).unwrap();
+
+    let sql = sql! {
+        INSERT INTO users (username, email, address)
+        VALUES
+            ("raw_execute", "raw_execute@icloud.com", "raw_execute_address");
+
+        DELETE FROM users
+        WHERE username = "raw_execute";
+    };
+
+    let results = sqlite::raw_execute(&conn, &sql);
+
+    assert!(!results.is_err());
+}


### PR DESCRIPTION
The previous implementations only allow for selecting. This implementation allows for all other SQL query types:

```rust
#[test]
fn execute_raw_sql() {
    let db_relative_path = "./db/insert.db";
    let db_path = Path::new(&db_relative_path);
    let conn = sqlite::open(db_path).unwrap();

    let sql = sql! {
        INSERT INTO users (username, email, address)
        VALUES
            ("raw_execute", "raw_execute@icloud.com", "raw_execute_address");

        DELETE FROM users
        WHERE username = "raw_execute";
    };

    let results = sqlite::raw_execute(&conn, &sql);

    assert!(!results.is_err());
}
```